### PR TITLE
Update README cloning instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,8 @@ This is designed only for **dev, not for production**. Weakness includes:
 
 - Clone the repo: (see [this Stack Overflow answer](https://stackoverflow.com/q/3796927/92837))
 
-      git clone --recurse-submodules git@github.com:BarcampBangalore/bcb-docker.git
-      
+      git clone --recurse-submodules --remote git@github.com:BarcampBangalore/bcb-docker.git
+
  - place `bcbwp.sql` file in `migration-scripts/` directory
  - Start Compose
  


### PR DESCRIPTION
Added the `--remote` tag to the recursive clone instructions, which pulls the latest commit off of the submodules